### PR TITLE
.OBJ with Vertex Color Support

### DIFF
--- a/g3d/model.lua
+++ b/g3d/model.lua
@@ -32,11 +32,12 @@ model.shader = g3d.shader
 -- translation, rotation, and scale are all 3d vectors and are all optional
 local function newModel(verts, texture, translation, rotation, scale)
     local self = setmetatable({}, model)
+    local map
 
     -- if verts is a string, use it as a path to a .obj file
     -- otherwise verts is a table, use it as a model defintion
     if type(verts) == "string" then
-        verts = loadObjFile(verts)
+        verts, map = loadObjFile(verts)
     end
 
     -- if texture is a string, use it as a path to an image file
@@ -50,6 +51,9 @@ local function newModel(verts, texture, translation, rotation, scale)
     self.texture = texture
     self.mesh = love.graphics.newMesh(self.vertexFormat, self.verts, "triangles")
     self.mesh:setTexture(self.texture)
+    if map then
+        self.mesh:setVertexMap(map)
+    end
     self.matrix = newMatrix()
     if type(scale) == "number" then scale = {scale, scale, scale} end
     self:setTransform(translation or {0,0,0}, rotation or {0,0,0}, scale or {1,1,1})

--- a/g3d/objloader.lua
+++ b/g3d/objloader.lua
@@ -25,8 +25,13 @@ return function (path, uFlip, vFlip)
 
         if firstWord == "v" then
             -- if the first word in this line is a "v", then this defines a vertex's position
+			-- for an unofficial .OBJ format (supported in blender), it can also contain color information
 
-            table.insert(positions, {tonumber(words[2]), tonumber(words[3]), tonumber(words[4])})
+			local t = {}
+			for i=2,#words do
+				t[i-1] = tonumber(words[i])
+			end
+			table.insert(positions, t)
         elseif firstWord == "vt" then
             -- if the first word in this line is a "vt", then this defines a texture coordinate
 
@@ -44,7 +49,7 @@ return function (path, uFlip, vFlip)
 
             -- if the first word in this line is a "f", then this is a face
             -- a face takes three point definitions
-            -- the arguments a point definition takes are vertex, vertex texture, vertex normal in that order
+            -- the arguments a point definition takes are vertex (and color), vertex texture, vertex normal in that order
 
             local vertices = {}
             for i = 2, #words do
@@ -59,6 +64,9 @@ return function (path, uFlip, vFlip)
                     vn and normals[vn][1] or 0,
                     vn and normals[vn][2] or 0,
                     vn and normals[vn][3] or 0,
+					v and positions[v][4],
+					v and positions[v][5],
+					v and positions[v][6],
                 })
             end
 


### PR DESCRIPTION
Still compatible with the original .OBJ format
This mod of .OBJ is can be exported in Blender since 2.79
Just add the vertex colors and export with the option enabled
Compatible with the shader provided in G3D